### PR TITLE
Added video_thruplay_watched_actions and video_play_actions fields

### DIFF
--- a/tap_facebook/schemas/ads_insights.json
+++ b/tap_facebook/schemas/ads_insights.json
@@ -14,6 +14,8 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_thruplay_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_actions": {"$ref": "ads_action_stats.json"},
     "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "clicks": {
       "type": [

--- a/tap_facebook/schemas/ads_insights_platform_and_device.json
+++ b/tap_facebook/schemas/ads_insights_platform_and_device.json
@@ -14,6 +14,8 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_thruplay_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_actions": {"$ref": "ads_action_stats.json"},
     "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "impression_device": {
       "type": [


### PR DESCRIPTION
# Description of change
Added video_thruplay_watched_actions and video_play_actions fields to ads_insights and ads_insights_platform_and_device streams.

[Jira Link](https://vmproduct.atlassian.net/browse/CDT-226)

# Manual QA steps
 - Check if Meltano pipeline extracts these additional fields through tap-facebook extractor
 - Additionally check if data is loaded into target as expected
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
