### PR TITLE
handle fb_error['body']['error'] being string instead of dict

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -127,10 +127,15 @@ def raise_from(singer_error, fb_error):
     """
     if isinstance(fb_error, FacebookRequestError):
         http_method = fb_error.request_context().get('method', 'Unknown HTTP Method')
+        fb_error_body = fb_error.body().get('error', {})
+        if isinstance(fb_error_body, dict):
+            fb_error_message = fb_error_body.get('message')
+        else:
+            fb_error_message = fb_error_body
         error_message = '{}: {} Message: {}'.format(
             http_method,
             fb_error.http_status(),
-            fb_error.body().get('error', {}).get('message')
+            fb_error_message
         )
     else:
         # All other facebook errors are `FacebookError`s and we handle


### PR DESCRIPTION
Ironically the tap fails when handling an error so even when this fix is deployed the error itself will will still be thrown. Seems like we're accessing a field in the error response as though it's a `dict` when it's a `str` in this case
![Screen Shot 2022-08-24 at 9 20 37 AM](https://user-images.githubusercontent.com/34848565/186429051-4b49411f-af7c-4aef-9abd-040d525f5f17.png)

