### PR TITLE
fix(backend): retry paginated insights and preserve fb errors

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -127,11 +127,13 @@ def raise_from(singer_error, fb_error):
     """
     if isinstance(fb_error, FacebookRequestError):
         http_method = fb_error.request_context().get('method', 'Unknown HTTP Method')
-        fb_error_body = fb_error.body().get('error', {})
+        fb_error_body = extract_facebook_error_body(fb_error)
         if isinstance(fb_error_body, dict):
             fb_error_message = fb_error_body.get('message')
         else:
             fb_error_message = fb_error_body
+        if not fb_error_message:
+            fb_error_message = 'Unknown Facebook error response'
         error_message = '{}: {} Message: {}'.format(
             http_method,
             fb_error.http_status(),
@@ -142,6 +144,23 @@ def raise_from(singer_error, fb_error):
         # them the same as a python error
         error_message = str(fb_error)
     raise singer_error(error_message) from fb_error
+
+def extract_facebook_error_body(fb_error):
+    body = fb_error.body()
+    if isinstance(body, dict):
+        return body.get('error', {})
+    if isinstance(body, str):
+        stripped_body = body.strip()
+        if not stripped_body:
+            return {}
+        try:
+            parsed_body = json.loads(stripped_body)
+        except ValueError:
+            return stripped_body
+        if isinstance(parsed_body, dict):
+            return parsed_body.get('error', parsed_body)
+        return stripped_body
+    return {}
 
 def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
     def log_retry_attempt(details):
@@ -664,6 +683,19 @@ class AdsInsights(Stream):
         job = job.api_get()
         return job
 
+    @staticmethod
+    @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
+    def __load_next_page_with_retry(results):
+        return results.load_next_page()
+
+    @staticmethod
+    def __iter_results(results):
+        while True:
+            while results._queue:
+                yield results._queue.pop(0)
+            if not AdsInsights.__load_next_page_with_retry(results):
+                return
+
     @retry_pattern(backoff.expo, (Timeout, ConnectionError), max_tries=5, factor=2)
     # Added retry_pattern to handle AttributeError raised from requests call below
     @retry_pattern(backoff.expo, (FacebookRequestError, InsightsJobTimeout, FacebookBadObjectError, TypeError, AttributeError), max_tries=5, factor=5)
@@ -714,7 +746,7 @@ class AdsInsights(Stream):
 
             min_date_start_for_job = None
             count = 0
-            for obj in job.get_result():
+            for obj in self.__iter_results(job.get_result()):
                 count += 1
                 rec = obj.export_all_data()
                 if not min_date_start_for_job or rec['date_stop'] < min_date_start_for_job:

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -259,3 +259,47 @@ class TestInsightJobs(unittest.TestCase):
         ad_insights_object.run_job({})
         self.assertEquals(3, mocked_account.get_insights.return_value.api_get.call_count)
         self.assertEquals(1, mocked_account.get_insights.call_count)
+
+    @patch('time.sleep', return_value=None)
+    def test_result_pagination_retry_succeeds_eventually(self, _sleep):
+        """AdsInsights iteration should retry transient page-load failures."""
+
+        mocked_bad_response = FacebookRequestError(
+            message='Call was not successful',
+            request_context={'method': 'GET'},
+            http_status=500,
+            http_headers=Mock(),
+            body='',
+        )
+
+        mocked_record = Mock()
+        mocked_record.export_all_data.return_value = {'date_stop': '2026-03-10'}
+
+        class MockResults:
+            def __init__(self):
+                self._queue = []
+                self.load_next_page = Mock(side_effect=self._side_effect)
+                self._calls = 0
+
+            def _side_effect(self):
+                self._calls += 1
+                if self._calls == 1:
+                    raise mocked_bad_response
+                if self._calls == 2:
+                    self._queue.append(mocked_record)
+                    return True
+                return False
+
+        mocked_results = MockResults()
+        mocked_job = Mock()
+        mocked_job.get_result.return_value = mocked_results
+
+        ad_insights_object = AdsInsights('', Mock(), '', '', {}, {})
+        ad_insights_object.job_params = Mock(return_value=iter([{'time_ranges': [{'until': '2026-03-10'}]}]))
+        ad_insights_object.run_job = Mock(return_value=mocked_job)
+
+        messages = list(ad_insights_object)
+
+        self.assertEqual(2, len(messages))
+        self.assertEqual({'date_stop': '2026-03-10'}, messages[0]['record'])
+        self.assertEqual(3, mocked_results.load_next_page.call_count)

--- a/tests/unittests/test_tap_facebook.py
+++ b/tests/unittests/test_tap_facebook.py
@@ -1,10 +1,10 @@
 import itertools
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 import pendulum
 import tap_facebook
 
-from tap_facebook import AdsInsights
+from tap_facebook import AdsInsights, FacebookRequestError
 from singer.catalog import Catalog, CatalogEntry
 from singer.schema import Schema
 from singer.utils import strftime, parse_args
@@ -153,6 +153,20 @@ class TestErrorHandling(unittest.TestCase):
     def test_sync(self):
         with self.assertRaises(SingerSyncError):
             tap_facebook.main()
+
+    def test_raise_from_handles_empty_string_error_body(self):
+        with self.assertRaises(SingerSyncError) as error:
+            tap_facebook.raise_from(
+                SingerSyncError,
+                FacebookRequestError(
+                    message='Call was not successful',
+                    request_context={'method': 'GET'},
+                    http_status=500,
+                    http_headers=Mock(),
+                    body='',
+                ),
+            )
+        self.assertEqual('GET: 500 Message: Unknown Facebook error response', str(error.exception))
 
 
 


### PR DESCRIPTION
## Summary
- preserve the original FacebookRequestError when the SDK returns an empty-string body
- retry transient failures while loading additional insights result pages
- add regression coverage for empty error bodies and paginated insights retries

## Testing
- python3 -m py_compile tap_facebook/__init__.py tests/unittests/test_tap_facebook.py tests/unittests/test_retry_logic.py
- unable to run pytest locally because the repo dependencies and pytest are not installed, and installing them was not approved in this session